### PR TITLE
i18n + navbar compacto + ajustes de estilo

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { fileURLToPath } from 'node:url';
 import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
@@ -22,4 +23,11 @@ export default defineConfig({
   },
   // If Bun has issues building native sharp, use Squoosh fallback:
   // image: { service: { entrypoint: 'astro/assets/services/squoosh' } }
+  vite: {
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
+  },
 });

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -110,7 +110,7 @@ import { getT, onLangChange } from '../i18n/index.ts';
     </div>
 
     <script type="module">
-      import { getT, onLangChange } from '/src/i18n/index.ts';
+      import { getT, onLangChange } from '@/i18n/index.ts';
       // Replace labels from i18n on language change (client-side enhancement)
       const t = (path) => {
         try {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,7 +21,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <script type="module">
-  import { getT, onLangChange } from '/src/i18n/index.ts';
+  import { getT, onLangChange } from '@/i18n/index.ts';
   const t = (k) => {
     try {
       return getT(document.documentElement.lang)(k);

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { getT, onLangChange } from '/src/i18n/index.ts';
+import { getT, onLangChange } from '@/i18n/index.ts';
 import ProjectCard from '../components/ProjectCard.astro';
 import { getCollection } from 'astro:content';
 
@@ -53,7 +53,7 @@ const cards = posts.map((p) => ({
 </BaseLayout>
 
 <script type="module">
-  import { getT, onLangChange } from '/src/i18n/index.ts';
+  import { getT, onLangChange } from '@/i18n/index.ts';
   const t = (k) => {
     try {
       return getT(document.documentElement.lang)(k);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -191,7 +191,7 @@ const padded = [
 </BaseLayout>
 
 <script type="module">
-  import { getT, onLangChange } from '/src/i18n/index.ts';
+  import { getT, onLangChange } from '@/i18n/index.ts';
   const t = (key) => {
     try {
       return getT(document.documentElement.lang)(key);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
Este PR incluye:
- Toggle de idioma (es/en) y textos dinámicos (i18n) para home, about y nav.
- Navbar sticky con modo compacto al hacer scroll, sombra y reducción de tamaños internos.
- Ajustes de espaciados en home (hero y “Sobre mí”).
- Sombras consistentes en botones y tarjetas.
- Alias @ configurado para i18n (imports estables en prod).

Listo para merge. 